### PR TITLE
Feature/Add ScreenSize Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`convert-4` is a simple library for converting between units of measurement, focusing on data size conversions. It supports a wide range of units from bits to terabytes, both in base 10 and base 2.
+`convert-4` is a versatile library for converting between various units of measurement, focusing on data size and screen size conversions. It supports a wide range of units, from bits to terabytes, as well as different units of screen dimensions (e.g., inches, pixels, points, and more).
 
 ## Installation
 
@@ -14,7 +14,9 @@ npm install convert-4
 
 ## Usage
 
-Here's a quick example of how to use `convert-4` to convert between different units of data size:
+Here's a quick example of how to use `convert-4` for both data size and screen size conversions.
+
+### Data Size Example:
 
 ```typescript
 import { DataSize } from "convert-4";
@@ -24,6 +26,18 @@ const dataSize = DataSize.fromBytes(1000);
 
 // Convert to kilobytes
 console.log(dataSize.toKilobytes()); // Output: 1
+```
+
+### Screen Size Example:
+
+```typescript
+import { ScreenSize } from "convert-4";
+
+// Create a ScreenSize instance from inches
+const screenSize = ScreenSize.fromInches(1);
+
+// Convert to points
+console.log(screenSize.toPoints()); // Output: 72
 ```
 
 ## API Reference
@@ -41,6 +55,22 @@ console.log(dataSize.toKilobytes()); // Output: 1
 - `fromTerabytes(value: number): DataSize`: Creates a new `DataSize` instance from a specified number of terabytes (base 10).
 
 For more detailed information, refer to the [`DataSize`](packages/converters/data-size.ts) class documentation in the [`packages/converters/README.md`](packages/converters/README.md) file.
+
+### ScreenSize Class
+
+The `ScreenSize` class provides functionality for converting between various units of screen size, such as inches, pixels, points, picas, centimeters, and millimeters.
+
+#### Static Methods
+
+- `from(data: OptionalFromScreenSize): ScreenSize`: Creates a new `ScreenSize` instance from an object specifying units of screen size.
+- `fromInches(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of inches.
+- `fromPixels(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of pixels.
+- `fromPoints(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of points.
+- `fromCentimeters(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of centimeters.
+- `fromMillimeters(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of millimeters.
+- `fromPicas(value: number): ScreenSize`: Creates a new `ScreenSize` instance from a specified number of picas.
+
+For more detailed information, refer to the [`ScreenSize`](doc/screen-size.md) documentation.
 
 ## License
 

--- a/docs/screen-size.md
+++ b/docs/screen-size.md
@@ -1,0 +1,145 @@
+## Documentation for `ScreenSize` Class
+
+The `ScreenSize` class allows for easy conversion between different units of screen measurement (inches, points, pixels, centimeters, etc.). This document outlines the usage, functionality, and basic tests to illustrate how to interact with the class.
+
+### Key Features
+- Supports conversions between various units: inches, points, pixels, centimeters, millimeters, picas, etc.
+- Provides static constructors to initialize the class using any unit.
+- Allows converting to different units once the `ScreenSize` object is created.
+- Ensures valid inputs and throws appropriate errors for invalid cases.
+- Handles both full and abbreviated unit names.
+
+### Importing the Class
+```typescript
+import { ScreenSize } from "convert-4";
+```
+
+### Creating a `ScreenSize` Object
+
+You can create a `ScreenSize` instance using one of the static `from` methods. These methods initialize the class with a value for a particular unit:
+
+#### Full Unit Name
+```typescript
+const screenSize = ScreenSize.from({ centimeters: 2.54 });
+```
+
+#### Abbreviated Unit Name
+```typescript
+const screenSize = ScreenSize.from({ cm: 2.54 });
+```
+
+You can also use specific factory methods for each unit:
+
+```typescript
+const screenSizeFromInches = ScreenSize.fromInches(1);  // Create ScreenSize from inches
+const screenSizeFromPoints = ScreenSize.fromPoints(72); // Create ScreenSize from points
+```
+
+### Available Static `from` Methods
+- `ScreenSize.from(data: OptionalFromScreenSize)`: Create a `ScreenSize` object from a variety of unit inputs.
+- `ScreenSize.fromPoints(value: number)`: Create a `ScreenSize` object from a point value.
+- `ScreenSize.fromPixels(value: number)`: Create a `ScreenSize` object from a pixel value.
+- `ScreenSize.fromInches(value: number)`: Create a `ScreenSize` object from an inch value.
+- `ScreenSize.fromCentimeters(value: number)`: Create a `ScreenSize` object from a centimeter value.
+- `ScreenSize.fromMillimeters(value: number)`: Create a `ScreenSize` object from a millimeter value.
+- `ScreenSize.fromPicas(value: number)`: Create a `ScreenSize` object from a pica value.
+
+### Conversion Methods
+Once a `ScreenSize` object is created, you can convert between units using the following methods:
+
+- `toPoints()`: Convert the stored value(s) to points.
+- `toPixels()`: Convert the stored value(s) to pixels.
+- `toInches()`: Convert the stored value(s) to inches.
+- `toCentimeters()`: Convert the stored value(s) to centimeters.
+- `toMillimeters()`: Convert the stored value(s) to millimeters.
+- `toPicas()`: Convert the stored value(s) to picas.
+
+### Example Usage
+
+```typescript
+// Convert from points to inches
+const screenSize = ScreenSize.fromPoints(72);
+console.log(screenSize.toInches()); // Output: 1
+
+// Convert from centimeters to inches
+const screenSizeInCm = ScreenSize.fromCentimeters(2.54);
+console.log(screenSizeInCm.toInches()); // Output: 1
+```
+
+### Error Handling
+The `ScreenSize` class will throw errors if invalid input is provided. For example:
+
+- **Invalid key**: If you provide an unrecognized unit:
+  ```typescript
+  ScreenSize.from({ invalidUnit: 10 });  // Throws: Invalid key: invalidUnit
+  ```
+  
+- **Negative values**: Units cannot be negative:
+  ```typescript
+  ScreenSize.from({ inches: -1 });  // Throws: Invalid value for inches: cannot be negative
+  ```
+
+- **Non-numeric values**: The class expects numeric inputs:
+  ```typescript
+  ScreenSize.from({ inches: "test" as any });  // Throws: Invalid value for inches: must be a number
+  ```
+
+- **No units specified**: If no units are provided, an error will be thrown:
+  ```typescript
+  ScreenSize.from({});  // Throws: At least one unit must be specified.
+  ```
+
+### Mixed Unit Conversions
+
+You can initialize `ScreenSize` with multiple units, and the conversions will sum them appropriately:
+
+```typescript
+const screenSize = ScreenSize.from({
+  inches: 1,
+  points: 72,
+  centimeters: 2.54,
+});
+console.log(screenSize.toInches()); // Output: 3
+console.log(screenSize.toPoints()); // Output: 216
+```
+
+### Testing
+
+#### Unit Conversion Tests
+```typescript
+describe("ScreenSize Tests", () => {
+  it("fromPoints toInches", () => {
+    const screenSize = ScreenSize.fromPoints(72);
+    expect(screenSize.toInches()).toEqual(1);
+  });
+
+  it("fromCentimeters toInches", () => {
+    const screenSize = ScreenSize.fromCentimeters(2.54);
+    expect(screenSize.toInches()).toEqual(1);
+  });
+
+  it("fromMillimeters toCentimeters", () => {
+    const screenSize = ScreenSize.fromMillimeters(10);
+    expect(screenSize.toCentimeters()).toEqual(1);
+  });
+});
+```
+
+#### Error Handling Tests
+```typescript
+describe("Validation and Error Handling", () => {
+  it("should throw an error with invalid keys", () => {
+    expect(() => ScreenSize.from({ invalid: 10 })).toThrow("Invalid key: invalid");
+  });
+
+  it("should throw an error when a negative value is provided", () => {
+    expect(() => ScreenSize.from({ inches: -1 })).toThrow("Invalid value for inches: cannot be negative");
+  });
+
+  it("should throw an error when no units are provided", () => {
+    expect(() => ScreenSize.from({})).toThrow("At least one unit must be specified.");
+  });
+});
+```
+
+This should give you a solid foundation for understanding and using the `ScreenSize` class!

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,2 +1,3 @@
 export * from "./data-size";
 export * from "./temperature";
+export * from "./screen-size";

--- a/packages/screen-size.ts
+++ b/packages/screen-size.ts
@@ -1,0 +1,152 @@
+export type FromScreenSize = {
+  pt: number;
+  px: number;
+  in: number;
+  cm: number;
+  mm: number;
+  pc: number;
+  picas: number;
+  points: number;
+  pixels: number;
+  inches: number;
+  centimeters: number;
+  millimeters: number;
+};
+
+export type OptionalFromScreenSize = Partial<FromScreenSize>;
+
+export class ScreenSize {
+  static readonly CM_PER_INCH = 2.54;
+  static readonly MM_PER_INCH = 25.4;
+  static readonly PICAS_PER_INCH = 6;
+  static readonly POINT_PER_INCH = 72;
+  static readonly PIXELS_PER_INCH = 72;
+
+  private data: FromScreenSize;
+
+  private validation(data: OptionalFromScreenSize) {
+    const keys = Object.keys(data);
+    const validKeys = [
+      "pt",
+      "px",
+      "in",
+      "cm",
+      "mm",
+      "pc",
+      "picas",
+      "points",
+      "pixels",
+      "inches",
+      "centimeters",
+      "millimeters",
+    ];
+
+    keys.forEach((key) => {
+      if (!validKeys.includes(key)) {
+        throw new Error(`Invalid key: ${key}`);
+      }
+
+      if (typeof data[key as keyof OptionalFromScreenSize] !== "number") {
+        throw new Error(`Invalid value for ${key}: must be a number`);
+      }
+    });
+  }
+
+  private constructor(data: OptionalFromScreenSize) {
+    this.validation(data);
+    this.data = {
+      pc: data.pc || 0,
+      pt: data.pt || 0,
+      px: data.px || 0,
+      in: data.in || 0,
+      cm: data.cm || 0,
+      mm: data.mm || 0,
+      picas: data.picas || 0,
+      pixels: data.pixels || 0,
+      points: data.points || 0,
+      inches: data.inches || 0,
+      millimeters: data.millimeters || 0,
+      centimeters: data.centimeters || 0,
+    };
+  }
+
+  static from(data: OptionalFromScreenSize) {
+    return new ScreenSize(data);
+  }
+
+  static fromPoints(value: number): ScreenSize {
+    return new ScreenSize({ pt: value });
+  }
+
+  static fromPixels(value: number): ScreenSize {
+    return new ScreenSize({ px: value });
+  }
+
+  static fromInches(value: number): ScreenSize {
+    return new ScreenSize({ in: value });
+  }
+
+  static fromCentimeters(value: number): ScreenSize {
+    return new ScreenSize({ cm: value });
+  }
+
+  static fromMillimeters(value: number): ScreenSize {
+    return new ScreenSize({ mm: value });
+  }
+
+  static fromPicas(value: number): ScreenSize {
+    return new ScreenSize({ pc: value });
+  }
+
+  calculateSize(divider: number): number {
+    const values = {
+      in: this.data.in / divider,
+      inches: this.data.inches / divider,
+      pt: this.data.pt / ScreenSize.POINT_PER_INCH / divider,
+      px: this.data.px / ScreenSize.PIXELS_PER_INCH / divider,
+      points: this.data.points / ScreenSize.POINT_PER_INCH / divider,
+      pixels: this.data.pixels / ScreenSize.PIXELS_PER_INCH / divider,
+      mm: this.data.mm / ScreenSize.MM_PER_INCH / divider,
+      cm: this.data.cm / ScreenSize.CM_PER_INCH / divider,
+      pc: this.data.pc / ScreenSize.PICAS_PER_INCH / divider,
+      picas: this.data.picas / ScreenSize.PICAS_PER_INCH / divider,
+      millimeters: this.data.millimeters / ScreenSize.MM_PER_INCH / divider,
+      centimeters: this.data.centimeters / ScreenSize.CM_PER_INCH / divider,
+    };
+    return Object.values(values).reduce((acc, curr) => acc + curr, 0);
+  }
+
+  toPoints(): number {
+    return parseFloat(
+      this.calculateSize(1 / ScreenSize.POINT_PER_INCH).toFixed(2)
+    );
+  }
+
+  toPixels(): number {
+    return parseFloat(
+      this.calculateSize(1 / ScreenSize.PIXELS_PER_INCH).toFixed(2)
+    );
+  }
+
+  toInches(): number {
+    return parseFloat(this.calculateSize(1).toFixed(2));
+  }
+
+  toCentimeters(): number {
+    return parseFloat(
+      this.calculateSize(1 / ScreenSize.CM_PER_INCH).toFixed(2)
+    );
+  }
+
+  toMillimeters(): number {
+    return parseFloat(
+      this.calculateSize(1 / ScreenSize.MM_PER_INCH).toFixed(2)
+    );
+  }
+
+  toPicas(): number {
+    return parseFloat(
+      this.calculateSize(1 / ScreenSize.PICAS_PER_INCH).toFixed(2)
+    );
+  }
+}

--- a/packages/screen-size.ts
+++ b/packages/screen-size.ts
@@ -63,18 +63,18 @@ export class ScreenSize {
   private constructor(measure: OptionalFromScreenSize) {
     this.validation(measure);
     this.measure = {
-      pc: measure.pc || 0,
-      pt: measure.pt || 0,
-      px: measure.px || 0,
-      in: measure.in || 0,
-      cm: measure.cm || 0,
-      mm: measure.mm || 0,
-      picas: measure.picas || 0,
-      pixels: measure.pixels || 0,
-      points: measure.points || 0,
-      inches: measure.inches || 0,
-      millimeters: measure.millimeters || 0,
-      centimeters: measure.centimeters || 0,
+      pc: measure.pc ?? 0,
+      pt: measure.pt ?? 0,
+      px: measure.px ?? 0,
+      in: measure.in ?? 0,
+      cm: measure.cm ?? 0,
+      mm: measure.mm ?? 0,
+      picas: measure.picas ?? 0,
+      pixels: measure.pixels ?? 0,
+      points: measure.points ?? 0,
+      inches: measure.inches ?? 0,
+      millimeters: measure.millimeters ?? 0,
+      centimeters: measure.centimeters ?? 0,
     };
   }
 
@@ -142,7 +142,7 @@ export class ScreenSize {
 
   private toUnit(unit: keyof FromScreenSize): number {
     const fromUnits = Object.keys(this.measure).filter(
-      (key) => this.measure[key as keyof FromScreenSize]! > 0
+      (key) => this.measure[key as keyof FromScreenSize] > 0
     ) as Array<keyof FromScreenSize>;
 
     if (fromUnits.length === 0) {

--- a/packages/screen-size.ts
+++ b/packages/screen-size.ts
@@ -126,16 +126,16 @@ export class ScreenSize {
       centimeters: ScreenSize.CM_PER_INCH,
     };
 
-    if (!(fromUnit in conversionRates)) {
+    const fromRate = conversionRates[fromUnit] as number;
+    const toRate = conversionRates[toUnit] as number;
+
+    if (!fromRate) {
       throw new Error(`Invalid 'from' unit: ${fromUnit}`);
     }
 
-    if (!(toUnit in conversionRates)) {
+    if (!toRate) {
       throw new Error(`Invalid 'to' unit: ${toUnit}`);
     }
-
-    const fromRate = conversionRates[fromUnit] as number;
-    const toRate = conversionRates[toUnit] as number;
 
     return (value / fromRate) * toRate;
   }

--- a/test/screen-size.spec.ts
+++ b/test/screen-size.spec.ts
@@ -1,0 +1,74 @@
+import { ScreenSize } from "../packages";
+
+describe("ScreenSize Tests", () => {
+  describe("Abbreviated Units", () => {
+    it("fromPoints toInches", () => {
+      const screenSize = ScreenSize.fromPoints(72);
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toPoints", () => {
+      const screenSize = ScreenSize.fromInches(1);
+      expect(screenSize.toPoints()).toEqual(72);
+    });
+    it("fromCentimeters toInches", () => {
+      const screenSize = ScreenSize.fromCentimeters(2.54);
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toCentimeters", () => {
+      const screenSize = ScreenSize.fromInches(1);
+      expect(screenSize.toCentimeters()).toEqual(2.54);
+    });
+    it("fromMillimeters toCentimeters", () => {
+      const screenSize = ScreenSize.fromMillimeters(10);
+      expect(screenSize.toCentimeters()).toEqual(1);
+    });
+    it("fromPicas toInches", () => {
+      const screenSize = ScreenSize.fromPicas(6);
+      expect(screenSize.toInches()).toEqual(1);
+    });
+  });
+
+  describe("Full Unit Names", () => {
+    it("fromPoints toInches using full names", () => {
+      const screenSize = ScreenSize.from({ points: 72 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toPoints using full names", () => {
+      const screenSize = ScreenSize.from({ inches: 1 });
+      expect(screenSize.toPoints()).toEqual(72);
+    });
+    it("fromCentimeters toInches using full names", () => {
+      const screenSize = ScreenSize.from({ centimeters: 2.54 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toCentimeters using full names", () => {
+      const screenSize = ScreenSize.from({ inches: 1 });
+      expect(screenSize.toCentimeters()).toEqual(2.54);
+    });
+    it("fromMillimeters toCentimeters using full names", () => {
+      const screenSize = ScreenSize.from({ millimeters: 10 });
+      expect(screenSize.toCentimeters()).toEqual(1);
+    });
+    it("fromPicas toInches using full names", () => {
+      const screenSize = ScreenSize.from({ picas: 6 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+  });
+
+  describe("Mixed Units", () => {
+    it("fromInches and Points mixed", () => {
+      const screenSize = ScreenSize.from({ inches: 1, points: 72 });
+      expect(screenSize.toInches()).toEqual(2);
+    });
+    it("fromCentimeters and Pixels mixed", () => {
+      const screenSize = ScreenSize.from({ centimeters: 2.54, pixels: 72 });
+      expect(screenSize.toInches()).toEqual(2);
+    });
+  });
+
+  it("should throw an error with invalid keys", () => {
+    expect(() => ScreenSize.from({ invalid: 10 } as any)).toThrow(
+      "Invalid key: invalid"
+    );
+  });
+});

--- a/test/screen-size.spec.ts
+++ b/test/screen-size.spec.ts
@@ -1,9 +1,17 @@
 import { ScreenSize } from "../packages";
 
 describe("ScreenSize Tests", () => {
-  describe("Abbreviated Units", () => {
+  describe("Conversions using fromFullUnitName Functions", () => {
+    it("fromPicas toInches", () => {
+      const screenSize = ScreenSize.fromPicas(6);
+      expect(screenSize.toInches()).toEqual(1);
+    });
     it("fromPoints toInches", () => {
       const screenSize = ScreenSize.fromPoints(72);
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromPixels toInches", () => {
+      const screenSize = ScreenSize.fromPixels(72);
       expect(screenSize.toInches()).toEqual(1);
     });
     it("fromInches toPoints", () => {
@@ -14,61 +22,181 @@ describe("ScreenSize Tests", () => {
       const screenSize = ScreenSize.fromCentimeters(2.54);
       expect(screenSize.toInches()).toEqual(1);
     });
-    it("fromInches toCentimeters", () => {
-      const screenSize = ScreenSize.fromInches(1);
-      expect(screenSize.toCentimeters()).toEqual(2.54);
-    });
     it("fromMillimeters toCentimeters", () => {
       const screenSize = ScreenSize.fromMillimeters(10);
       expect(screenSize.toCentimeters()).toEqual(1);
     });
-    it("fromPicas toInches", () => {
-      const screenSize = ScreenSize.fromPicas(6);
-      expect(screenSize.toInches()).toEqual(1);
-    });
   });
 
-  describe("Full Unit Names", () => {
-    it("fromPoints toInches using full names", () => {
-      const screenSize = ScreenSize.from({ points: 72 });
-      expect(screenSize.toInches()).toEqual(1);
-    });
-    it("fromInches toPoints using full names", () => {
-      const screenSize = ScreenSize.from({ inches: 1 });
-      expect(screenSize.toPoints()).toEqual(72);
-    });
-    it("fromCentimeters toInches using full names", () => {
-      const screenSize = ScreenSize.from({ centimeters: 2.54 });
-      expect(screenSize.toInches()).toEqual(1);
-    });
-    it("fromInches toCentimeters using full names", () => {
-      const screenSize = ScreenSize.from({ inches: 1 });
-      expect(screenSize.toCentimeters()).toEqual(2.54);
-    });
-    it("fromMillimeters toCentimeters using full names", () => {
-      const screenSize = ScreenSize.from({ millimeters: 10 });
-      expect(screenSize.toCentimeters()).toEqual(1);
-    });
-    it("fromPicas toInches using full names", () => {
+  describe("Conversions using from {FullUnitName}", () => {
+    it("fromPicas toInches", () => {
       const screenSize = ScreenSize.from({ picas: 6 });
       expect(screenSize.toInches()).toEqual(1);
     });
+    it("fromPoints toInches", () => {
+      const screenSize = ScreenSize.from({ points: 72 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toPoints", () => {
+      const screenSize = ScreenSize.from({ inches: 1 });
+      expect(screenSize.toPoints()).toEqual(72);
+    });
+    it("fromCentimeters toInches", () => {
+      const screenSize = ScreenSize.from({ centimeters: 2.54 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromPixels toInches", () => {
+      const screenSize = ScreenSize.from({ pixels: 72 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromMillimeters toCentimeters", () => {
+      const screenSize = ScreenSize.from({ millimeters: 10 });
+      expect(screenSize.toCentimeters()).toEqual(1);
+    });
   });
 
-  describe("Mixed Units", () => {
-    it("fromInches and Points mixed", () => {
-      const screenSize = ScreenSize.from({ inches: 1, points: 72 });
-      expect(screenSize.toInches()).toEqual(2);
+  describe("Conversions using from {AbbreviatedUnitName}", () => {
+    it("fromPicas toInches", () => {
+      const screenSize = ScreenSize.from({ pc: 6 });
+      expect(screenSize.toInches()).toEqual(1);
     });
-    it("fromCentimeters and Pixels mixed", () => {
-      const screenSize = ScreenSize.from({ centimeters: 2.54, pixels: 72 });
-      expect(screenSize.toInches()).toEqual(2);
+    it("fromPoints toInches", () => {
+      const screenSize = ScreenSize.from({ pt: 72 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromInches toPoints", () => {
+      const screenSize = ScreenSize.from({ in: 1 });
+      expect(screenSize.toPoints()).toEqual(72);
+    });
+    it("fromCentimeters toInches", () => {
+      const screenSize = ScreenSize.from({ cm: 2.54 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromPixels toInches", () => {
+      const screenSize = ScreenSize.from({ px: 72 });
+      expect(screenSize.toInches()).toEqual(1);
+    });
+    it("fromMillimeters toCentimeters", () => {
+      const screenSize = ScreenSize.from({ mm: 10 });
+      expect(screenSize.toCentimeters()).toEqual(1);
     });
   });
 
-  it("should throw an error with invalid keys", () => {
-    expect(() => ScreenSize.from({ invalid: 10 } as any)).toThrow(
-      "Invalid key: invalid"
-    );
+  describe("Conversions with Mixed Units Summation", () => {
+    it("should convert from all units to all other possible units", () => {
+      const screenSize = ScreenSize.from({
+        inches: 1,
+        points: 72,
+        centimeters: 2.54,
+        millimeters: 25.4,
+        picas: 6,
+        pixels: 72,
+        pt: 72,
+        px: 72,
+        in: 1,
+        cm: 2.54,
+        mm: 25.4,
+        pc: 6,
+      });
+
+      expect(screenSize.toInches()).toEqual(12);
+      expect(screenSize.toPoints()).toEqual(864);
+      expect(screenSize.toCentimeters()).toEqual(30.48);
+      expect(screenSize.toMillimeters()).toEqual(304.8);
+      expect(screenSize.toPicas()).toEqual(72);
+      expect(screenSize.toPixels()).toEqual(864);
+    });
+  });
+
+  describe("Validation and Error Handling", () => {
+    it("should throw an error with invalid keys", () => {
+      expect(() => ScreenSize.from({ invalid: 10 } as any)).toThrow(
+        "Invalid key: invalid"
+      );
+    });
+
+    it("should throw an error if no units are provided", () => {
+      expect(() => ScreenSize.from({})).toThrow(
+        "At least one unit must be specified."
+      );
+    });
+
+    it("should throw an error when a negative value is provided", () => {
+      expect(() => ScreenSize.from({ inches: -1 })).toThrow(
+        "Invalid value for inches: cannot be negative"
+      );
+    });
+
+    it("should throw an error when a non-number value is provided", () => {
+      expect(() => ScreenSize.from({ inches: "test" as any })).toThrow(
+        "Invalid value for inches: must be a number"
+      );
+    });
+
+    it("should throw an error when all units are zero", () => {
+      const screenSize = ScreenSize.from({
+        inches: 0,
+        points: 0,
+        centimeters: 0,
+        millimeters: 0,
+        picas: 0,
+        pixels: 0,
+        pt: 0,
+        px: 0,
+        in: 0,
+        cm: 0,
+        mm: 0,
+        pc: 0,
+      });
+      expect(() => screenSize.toInches()).toThrow(
+        "No units available for conversion."
+      );
+    });
+  });
+
+  describe("Precision Handling", () => {
+    it("should handle floating-point precision correctly in conversions", () => {
+      const screenSize = ScreenSize.from({ centimeters: 1.27 });
+      expect(screenSize.toInches()).toBeCloseTo(0.5, 6);
+    });
+
+    it("should handle extremely small values accurately", () => {
+      const screenSize = ScreenSize.from({ centimeters: 0.000254 });
+      expect(screenSize.toInches()).toBeCloseTo(0.0001, 6);
+    });
+  });
+
+  describe("Internal Conversion Logic", () => {
+    it("should correctly convert inches to centimeters", () => {
+      const screenSize = ScreenSize.fromInches(1);
+      const conversion = screenSize["convert"](1, "in", "cm");
+      expect(conversion).toEqual(2.54);
+    });
+
+    it("should correctly convert centimeters to inches", () => {
+      const screenSize = ScreenSize.fromCentimeters(2.54);
+      const conversion = screenSize["convert"](2.54, "cm", "in");
+      expect(conversion).toEqual(1);
+    });
+
+    it("should correctly convert pixels to inches", () => {
+      const screenSize = ScreenSize.fromPixels(72);
+      const conversion = screenSize["convert"](72, "px", "in");
+      expect(conversion).toEqual(1);
+    });
+
+    it("should throw an error for invalid fromUnit in conversion", () => {
+      const screenSize = ScreenSize.fromInches(1);
+      expect(() =>
+        screenSize["convert"](1, "invalidUnit" as any, "in")
+      ).toThrow("Invalid 'from' unit: invalidUnit");
+    });
+
+    it("should throw an error for invalid toUnit in conversion", () => {
+      const screenSize = ScreenSize.fromInches(1);
+      expect(() =>
+        screenSize["convert"](1, "in", "invalidUnit" as any)
+      ).toThrow("Invalid 'to' unit: invalidUnit");
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
### Pull Request: Add ScreenSize Functionality

#### Overview

This pull request introduces the `ScreenSize` class to the `convert-4` library, expanding its capabilities to include conversions between various screen size units. The new functionality allows users to easily convert between units such as inches, pixels, points, picas, centimeters, and millimeters.

#### Key Features

- **ScreenSize Class**: A new class dedicated to screen size conversions.
- **Static Methods**: Provides methods to create instances from different units, including:
  - `fromInches(value: number)`
  - `fromPixels(value: number)`
  - `fromPoints(value: number)`
  - `fromCentimeters(value: number)`
  - `fromMillimeters(value: number)`
  - `fromPicas(value: number)`
  - `from(data: OptionalFromScreenSize)`
- **Conversion Methods**: Enables conversions to various units through methods like `toInches()`, `toPixels()`, `toPoints()`, `toCentimeters()`, `toMillimeters()`, and `toPicas()`.
- **Input Validation**: Implements robust validation to ensure correct usage and prevent errors, including checks for negative values, non-numeric inputs, and invalid keys.

#### Documentation Updates

- The `README.md` file has been updated to include:
  - A new section detailing the `ScreenSize` class and its methods.
  - Examples demonstrating how to use the `ScreenSize` class for conversions.
  - A link to the dedicated documentation in `doc/screen-size.md`.

#### Testing

- Extensive tests have been added to ensure the accuracy and reliability of the conversion functionality, covering various scenarios, including:
  - Valid conversions from one unit to another.
  - Error handling for invalid inputs.
  - Precision handling for floating-point values.

#### Conclusion

This enhancement to the `convert-4` library allows users to perform screen size conversions seamlessly and efficiently, complementing the existing data size conversion functionality.